### PR TITLE
Fix typos

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -11,7 +11,7 @@ In effect mode, the voice generators are not used, and instead an external audio
 
 Due to the bundle format, InfernalSynth can easily be themed if you're comfortable editing json files.\
 See /Contents/Resources/Themes/(theme name)/themefile.json (VST3) or /Themes/(theme name)/themefile.json (CLAP). \
-It contains a root section definining all colors on a global level, an audio section containing overrides for the oscillator, \
+It contains a root section defining all colors on a global level, an audio section containing overrides for the oscillator, \
 fx and audio matrix, and a cv section containing overrides for the lfo, envelope and cv matrix. \
 The background images live in the same folder, they can be swapped for anything else as long as the other image has the same dimensions.
 
@@ -58,11 +58,11 @@ However, individual components are either bandlimited or have options to reduce 
     - Use the slope parameters to smooth out rough edges as needed.
 - Effects
     - Filter, Delay and Reverb do not introduce new harmonics.
-    - Waveshaper has an oversampling parameter to cut down aliasing to an acceptible level.
+    - Waveshaper has an oversampling parameter to cut down aliasing to an acceptable level.
 - Oscillators
     - DSF is bandlimited by definition.
     - Mix is a sum of bandlimited basic oscillators, see below.
-    - Noise is NOT bandlimited, use filters to get an acceptible audio signal.
+    - Noise is NOT bandlimited, use filters to get an acceptable audio signal.
     - Karplus-Strong has non-bandlimited transients, then quickly decays to sine.
     - Basic
         - Sine is bandlimited by definition.
@@ -226,7 +226,7 @@ Provides pitch translators affecting all oscillators, portamento settings and po
 - Mode: select polyphonic/monophonic mode.
     - Poly: regular polyphonic mode.
     - Mono: true monophonic mode (voice count will never exceed 1).
-    - Release: notes play in a single voice untill an explicit note-off is received. \
+    - Release: notes play in a single voice until an explicit note-off is received. \
     Then, a new monophonic section is started, while the release section of the previous one continues, so voice count may exceed 1.
 - Portamento
     - Time/tempo: glide time.
@@ -270,11 +270,11 @@ Please note: if release length is zero, envelope sustains at it's final pre-rele
 
 - Graphs: Envelope.
 - Type
-    - Sustain: regular sustain mode, holds at sustain level untill note off.
+    - Sustain: regular sustain mode, holds at sustain level until note off.
     - Follow: exactly follows the envelope, completely ignoring note-off (so, does NOT hold at sustain).
     - Release: follows the envelope, but enters release section as soon as note off is encountered (so, does NOT hold at sustain).
 - Mode: only pertains to non-polyphonic voice modes, i.e., only take effect within a monophonic section.
-    - Legato: envelope is not retriggered untill the next monophonic voice section.
+    - Legato: envelope is not retriggered until the next monophonic voice section.
     - Retrig: envelope is reset to zero and starts over at Attack when a new note is received.
     - Multi: envelope is reset to current level and starts over at Attack when a new note is received.
 - Bipolar: switch unipolar/bipolar mode.
@@ -286,7 +286,7 @@ Please note: if release length is zero, envelope sustains at it's final pre-rele
 - A1/D1/R1: duration of the first part of the attack, decay and release sections.
 - A2/D2/R2: duration of the second part of the attack, decay and release sections.
 - Slope1/2: slope of the first/second part of the attack, decay and release sections.
-- Sustain: sustain at this level after the decay section, and before the release section, untill a note-off event is received.
+- Sustain: sustain at this level after the decay section, and before the release section, until a note-off event is received.
 
 ## LFO section
 

--- a/src/inf.base.format.clap/inf.base.format.clap/clap_parameter.cpp
+++ b/src/inf.base.format.clap/inf.base.format.clap/clap_parameter.cpp
@@ -124,7 +124,7 @@ param_get_info(clap_plugin_t const* plugin, std::uint32_t param_index, clap_para
   param_info->id = inf_plugin->topology->param_index_to_id[param_index];
 
   // Just go with 0/1 to be the same as vst3 for real-valued, seems easier to do it like this.
-  // We still need to supply the full range for discrete values as clap doesnt do normalization for stepped params.
+  // We still need to supply the full range for discrete values as clap doesn't do normalization for stepped params.
   bool is_real = inf_info.descriptor->data.type == param_type::real;
   param_info->min_value = is_real ? 0.0f: inf_info.descriptor->data.discrete.min;
   param_info->max_value = is_real ? 1.0f : inf_info.descriptor->data.discrete.max;

--- a/src/inf.base/inf.base/plugin/state.hpp
+++ b/src/inf.base/inf.base/plugin/state.hpp
@@ -46,7 +46,7 @@ struct note_event
 // Shared input data in case of polyphonic synth.
 struct block_input_data
 {
-  // Block tempo. Vst3 doesnt handle this per-sample.
+  // Block tempo. Vst3 doesn't handle this per-sample.
   float bpm;
   // Audio input for effect.
   float const* const* audio;

--- a/src/inf.base/inf.base/shared/support.hpp
+++ b/src/inf.base/inf.base/shared/support.hpp
@@ -132,7 +132,7 @@ note_to_frequency_table(float midi)
 // These are helper functions to go from base (which is either discrete or 0..1)
 // to both VST3 and CLAP normalized values (always 0..1 for vst3, 0..1 for clap real or
 // min-max for clap discrete) to display values (e.g. -6..+6) to text values (e.g. "-6dB""). 
-// CLAP doesnt really need this 0-1 normalization but its easier to keep parity with vst3.
+// CLAP doesn't really need this 0-1 normalization but its easier to keep parity with vst3.
 
 inline double 
 discrete_to_format_normalized(

--- a/src/inf.base/inf.base/topology/param_descriptor.hpp
+++ b/src/inf.base/inf.base/topology/param_descriptor.hpp
@@ -73,7 +73,7 @@ struct discrete_descriptor
   std::vector<std::string> const* const names = {}; // Names for a knob-list parameter.
   list_item_enabled_selector enabled_selector = {}; // Optional.
   
-  // IO: false parses for UI (display name), true parses for persistance (guids).
+  // IO: false parses for UI (display name), true parses for persistence (guids).
   std::int32_t parse_ui(param_type type, std::int32_t part_index, char const* buffer) const;
   bool parse(param_type type, bool io, std::int32_t part_index, char const* buffer, std::int32_t& val) const;
 
@@ -199,7 +199,7 @@ struct param_descriptor_data
     discrete_descriptor const discrete; // Discrete valued specific data.
   };
 
-  // IO: false parses/formats for UI (display name), true parses/formats for persistance (guids).
+  // IO: false parses/formats for UI (display name), true parses/formats for persistence (guids).
   std::string format(bool io, param_value val) const;
   std::size_t format(bool io, param_value val, char* buffer, std::size_t size) const;
   param_value parse_ui(std::int32_t part_index, char const* buffer) const;

--- a/src/inf.plugin.infernal_synth/inf.plugin.infernal_synth/lfo/processor.cpp
+++ b/src/inf.plugin.infernal_synth/inf.plugin.infernal_synth/lfo/processor.cpp
@@ -134,7 +134,7 @@ lfo_processor::update_block_free(automation_view const& automation)
 template <class processor_type> void
 lfo_processor::process(float* rate, float* out, std::int32_t sample_count, processor_type processor)
 {
-  // Fill buffer untill we hit end of one-shot.
+  // Fill buffer until we hit end of one-shot.
   // Keep track of highest frequency for filter.
   _max_freq = 0.0f;
   _end_index = sample_count;

--- a/src/inf.plugin.infernal_synth/inf.plugin.infernal_synth/synth/processor.hpp
+++ b/src/inf.plugin.infernal_synth/inf.plugin.infernal_synth/synth/processor.hpp
@@ -34,7 +34,7 @@ public base::audio_processor
   // If a voice is activated within the current buffer,
   // it is considered taken from the beginning of the buffer.
   // Similarly, if a voice is finished within the current buffer,
-  // it is considered taken untill the end of the buffer.
+  // it is considered taken until the end of the buffer.
   // Keep track of last activated voice, seems the safer
   // way to do it when user is switching poly/mono modes on the fly.
   bool _voices_drained;


### PR DESCRIPTION
Found via `codespell -q 3 -S "./lib" -L inout,re-use `